### PR TITLE
fix(feed): allow float durations in logs

### DIFF
--- a/src/app/services/entries.py
+++ b/src/app/services/entries.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import math
 import csv
 import io
 import uuid
@@ -142,11 +143,11 @@ def import_entries_csv(db_path: str, user_slug: str, file_storage) -> dict:
             duration = None
             if duration_raw:
                 try:
-                    duration = int(duration_raw)
+                    duration = float(duration_raw)
                 except ValueError as exc:
-                    raise ValueError("duration must be an integer") from exc
-                if duration < 0:
-                    raise ValueError("duration must be a non-negative integer")
+                    raise ValueError("duration must be a number") from exc
+                if not math.isfinite(duration) or duration < 0:
+                    raise ValueError("duration must be a non-negative number")
             comment_raw = (row.get(field_map["comment"]) or "").strip()
             notes = comment_raw or None
         except ValueError as exc:
@@ -209,10 +210,12 @@ def update_entry(db_path: str, entry_id: int, payload: dict) -> dict:
         fields["formula_ml"] = payload["formula_ml"]
     if "feed_duration_min" in payload:
         if payload["feed_duration_min"] is not None and (
-            not isinstance(payload["feed_duration_min"], int)
+            not isinstance(payload["feed_duration_min"], (int, float))
+            or isinstance(payload["feed_duration_min"], bool)
+            or not math.isfinite(payload["feed_duration_min"])
             or payload["feed_duration_min"] < 0
         ):
-            raise ValueError("feed_duration_min must be a non-negative integer")
+            raise ValueError("feed_duration_min must be a non-negative number")
         fields["feed_duration_min"] = payload["feed_duration_min"]
     if "caregiver_id" in payload:
         fields["caregiver_id"] = payload["caregiver_id"]

--- a/src/app/storage/db.py
+++ b/src/app/storage/db.py
@@ -54,7 +54,7 @@ def _ensure_entry_type_constraint(conn: sqlite3.Connection) -> None:
             amount_ml INTEGER,
             expressed_ml INTEGER,
             formula_ml INTEGER,
-            feed_duration_min INTEGER,
+            feed_duration_min REAL,
             caregiver_id INTEGER,
             created_at_utc TEXT NOT NULL,
             updated_at_utc TEXT NOT NULL
@@ -101,7 +101,7 @@ def _ensure_feed_duration_column(conn: sqlite3.Connection) -> None:
         row["name"] for row in conn.execute("PRAGMA table_info(entries)").fetchall()
     }
     if "feed_duration_min" not in columns:
-        conn.execute("ALTER TABLE entries ADD COLUMN feed_duration_min INTEGER")
+        conn.execute("ALTER TABLE entries ADD COLUMN feed_duration_min REAL")
 
 
 def _ensure_feed_amount_columns(conn: sqlite3.Connection) -> None:

--- a/src/app/storage/schema.sql
+++ b/src/app/storage/schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS entries (
     amount_ml INTEGER,
     expressed_ml INTEGER,
     formula_ml INTEGER,
-    feed_duration_min INTEGER,
+    feed_duration_min REAL,
     caregiver_id INTEGER,
     created_at_utc TEXT NOT NULL,
     updated_at_utc TEXT NOT NULL

--- a/src/lib/validation.py
+++ b/src/lib/validation.py
@@ -1,7 +1,17 @@
+import math
 import re
 
 USER_SLUG_RE = re.compile(r"^[a-z0-9-]{1,24}$")
 ENTRY_TYPE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 /-]{0,31}$")
+
+
+def _is_non_negative_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+    )
 
 
 def validate_entry_type(value: str) -> None:
@@ -35,11 +45,8 @@ def validate_entry_payload(payload: dict, require_client_event: bool = False) ->
             raise ValueError("formula_ml must be a non-negative integer")
 
     if "feed_duration_min" in payload and payload["feed_duration_min"] is not None:
-        if (
-            not isinstance(payload["feed_duration_min"], int)
-            or payload["feed_duration_min"] < 0
-        ):
-            raise ValueError("feed_duration_min must be a non-negative integer")
+        if not _is_non_negative_number(payload["feed_duration_min"]):
+            raise ValueError("feed_duration_min must be a non-negative number")
 
     if "notes" in payload and payload["notes"] is not None:
         if not isinstance(payload["notes"], str):

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -1379,14 +1379,15 @@ function renderLogEntries(entries) {
     const right = document.createElement("div");
     right.className = "log-actions";
 
-    const amountEl = document.createElement("span");
-    amountEl.className = "entry-meta";
+    const amounts = [];
     if (entry.expressed_ml !== null && entry.expressed_ml !== undefined) {
-      amountEl.textContent = `Expressed ${entry.expressed_ml} ml`;
-    } else if (entry.formula_ml !== null && entry.formula_ml !== undefined) {
-      amountEl.textContent = `Formula ${entry.formula_ml} ml`;
-    } else if (entry.amount_ml !== null && entry.amount_ml !== undefined) {
-      amountEl.textContent = `${entry.amount_ml} ml`;
+      amounts.push({ label: "Expressed", value: entry.expressed_ml });
+    }
+    if (entry.formula_ml !== null && entry.formula_ml !== undefined) {
+      amounts.push({ label: "Formula", value: entry.formula_ml });
+    }
+    if (entry.amount_ml !== null && entry.amount_ml !== undefined) {
+      amounts.push({ label: "Amount", value: entry.amount_ml });
     }
 
     const editBtn = document.createElement("button");
@@ -1401,9 +1402,12 @@ function renderLogEntries(entries) {
     delBtn.textContent = "Delete";
     delBtn.addEventListener("click", () => deleteEntry(entry));
 
-    if (amountEl.textContent) {
+    amounts.forEach(({ label, value }) => {
+      const amountEl = document.createElement("span");
+      amountEl.className = "entry-meta";
+      amountEl.textContent = `${label} ${value} ml`;
       right.appendChild(amountEl);
-    }
+    });
     right.appendChild(editBtn);
     right.appendChild(timeBtn);
     right.appendChild(delBtn);
@@ -1608,8 +1612,8 @@ async function addEntry(type) {
     }
     const trimmed = minutesInput.trim();
     if (trimmed !== "") {
-      const minutes = Number.parseInt(trimmed, 10);
-      if (Number.isNaN(minutes) || minutes < 0) {
+      const minutes = Number.parseFloat(trimmed);
+      if (!Number.isFinite(minutes) || minutes < 0) {
         setStatus("Duration must be a non-negative number");
         return;
       }
@@ -1725,8 +1729,8 @@ async function editEntry(entry) {
     if (trimmed === "") {
       payload.feed_duration_min = null;
     } else {
-      const minutes = Number.parseInt(trimmed, 10);
-      if (Number.isNaN(minutes) || minutes < 0) {
+      const minutes = Number.parseFloat(trimmed);
+      if (!Number.isFinite(minutes) || minutes < 0) {
         setStatus("Duration must be a non-negative number");
         return;
       }

--- a/tests/integration/test_entries_api.py
+++ b/tests/integration/test_entries_api.py
@@ -180,7 +180,7 @@ def test_list_entries_accepts_plus_offset_in_query(client):
 def test_import_csv_entries(client):
     csv_data = (
         "timestamp,type,duration,comment\n"
-        "2024-01-01T01:00:00+00:00,feed,15,first feed\n"
+        "2024-01-01T01:00:00+00:00,feed,15.5,first feed\n"
         "2024-01-02T02:00:00+00:00,wee,,dry\n"
     )
     response = client.post(
@@ -195,7 +195,7 @@ def test_import_csv_entries(client):
     feed_response = client.get("/api/entries?type=feed")
     assert feed_response.status_code == 200
     feed_entries = feed_response.get_json()
-    assert feed_entries[0]["feed_duration_min"] == 15
+    assert feed_entries[0]["feed_duration_min"] == 15.5
     assert feed_entries[0]["notes"] == "first feed"
 
 


### PR DESCRIPTION
## Summary\n- allow decimal feed durations in validation, services, and CSV import\n- render all feed amounts in event log outputs\n- update schema defaults and tests for float durations\n\n## Testing\n- uv run pytest tests/integration/test_entries_api.py