### PR TITLE
fix(home): split next feed actions

### DIFF
--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -68,6 +68,7 @@ const statWindowEl = document.getElementById("stat-window");
 const lastActivityEl = document.getElementById("last-activity");
 const lastFeedEl = document.getElementById("last-feed");
 const nextFeedEl = document.getElementById("next-feed");
+const nextFeedShortcutEl = document.getElementById("next-feed-shortcut");
 const lastWeeEl = document.getElementById("last-wee");
 const lastPooEl = document.getElementById("last-poo");
 const statCardEls = document.querySelectorAll(".stat-card[data-log-type]");
@@ -395,6 +396,7 @@ function initHomeHandlers() {
     });
   }
   bindTimestampPopup(lastFeedEl);
+  bindTimestampPopup(nextFeedEl);
   bindTimestampPopup(lastWeeEl);
   bindTimestampPopup(lastPooEl);
   if (feedBtn) {
@@ -983,6 +985,20 @@ function buildFeedShortcutUrl(target) {
   return `shortcuts://run-shortcut?name=feedreminderpwa&input=${encoded}`;
 }
 
+function setNextFeedShortcut(enabled, href) {
+  if (!nextFeedShortcutEl) {
+    return;
+  }
+  nextFeedShortcutEl.classList.toggle("is-disabled", !enabled);
+  if (enabled && href) {
+    nextFeedShortcutEl.href = href;
+    nextFeedShortcutEl.removeAttribute("aria-disabled");
+  } else {
+    nextFeedShortcutEl.removeAttribute("href");
+    nextFeedShortcutEl.setAttribute("aria-disabled", "true");
+  }
+}
+
 function updateNextFeed() {
   if (!nextFeedEl) {
     return;
@@ -992,23 +1008,21 @@ function updateNextFeed() {
   if (!intervalMinutes || !lastTimestamp) {
     nextFeedEl.textContent = "--";
     nextFeedEl.removeAttribute("data-timestamp");
-    nextFeedEl.removeAttribute("href");
-    nextFeedEl.setAttribute("aria-disabled", "true");
+    setNextFeedShortcut(false, "");
     return;
   }
   const lastDate = new Date(lastTimestamp);
   if (Number.isNaN(lastDate.getTime())) {
     nextFeedEl.textContent = "--";
     nextFeedEl.removeAttribute("data-timestamp");
-    nextFeedEl.removeAttribute("href");
-    nextFeedEl.setAttribute("aria-disabled", "true");
+    setNextFeedShortcut(false, "");
     return;
   }
   const nextDate = new Date(lastDate.getTime() + intervalMinutes * 60000);
   nextFeedEl.textContent = formatTimeUntil(nextDate);
   nextFeedEl.dataset.timestamp = nextDate.toISOString();
-  nextFeedEl.href = buildFeedShortcutUrl(nextDate);
-  nextFeedEl.removeAttribute("aria-disabled");
+  const shortcutUrl = buildFeedShortcutUrl(nextDate);
+  setNextFeedShortcut(Boolean(shortcutUrl), shortcutUrl);
 }
 
 function bindTimestampPopup(element) {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -262,14 +262,33 @@
         font-weight: 600;
         color: #2d3b31;
         cursor: pointer;
-        text-decoration: none;
       }
       .last-time[href] {
         text-decoration: underline;
         text-decoration-style: dotted;
         text-underline-offset: 2px;
       }
+      .last-actions {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .shortcut-link {
+        font-weight: 600;
+        color: #2d3b31;
+        text-decoration: underline;
+        text-decoration-style: dotted;
+        text-underline-offset: 2px;
+      }
+      .shortcut-link.is-disabled {
+        opacity: 0.5;
+        pointer-events: none;
+        text-decoration: none;
+      }
       html.dark .last-time {
+        color: #dce8df;
+      }
+      html.dark .shortcut-link {
         color: #dce8df;
       }
       .log-link {
@@ -690,7 +709,10 @@
             <div class="last-row">
               <span class="legend-dot" style="background: #f6c453;"></span>
               <span>Next feed</span>
-              <a class="last-time" id="next-feed">--</a>
+              <span class="last-actions">
+                <span class="last-time" id="next-feed">--</span>
+                <a class="shortcut-link is-disabled" id="next-feed-shortcut" aria-label="Run feed reminder shortcut">Shortcut</a>
+              </span>
             </div>
             <div class="last-row">
               <span class="legend-dot" style="background: #7dd3fc;"></span>


### PR DESCRIPTION
## Summary\n- keep the next feed duration clickable for the timestamp popup\n- add a separate Shortcut link on the same line for the reminder\n- style and enable/disable the Shortcut link based on next feed availability\n\n## Testing\n- uv run pytest