### PR TITLE
fix(summary): focus on feed totals and milk express

### DIFF
--- a/src/web/templates/summary.html
+++ b/src/web/templates/summary.html
@@ -161,6 +161,16 @@
         gap: 12px;
         margin-bottom: 16px;
       }
+      .summary-section-title {
+        margin: 8px 2px 10px;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: #6a6259;
+      }
+      html.dark .summary-section-title {
+        color: #9db9a6;
+      }
       .summary-card {
         border-radius: 14px;
         padding: 12px;
@@ -193,73 +203,75 @@
       html.dark .summary-sub {
         color: #9db9a6;
       }
-      .chart-card {
+      .summary-panel {
         border-radius: 16px;
         padding: 14px;
         border: 1px solid #e5e1da;
         background: #ffffff;
       }
-      html.dark .chart-card {
+      html.dark .summary-panel {
         border-color: rgba(255, 255, 255, 0.08);
         background: rgba(26, 44, 32, 0.9);
       }
-      .chart-header {
+      .summary-panel-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 8px;
         margin-bottom: 10px;
       }
-      .chart-header h2 {
+      .summary-panel-header h2 {
         margin: 0;
         font-size: 16px;
       }
-      .chart-controls {
+      .summary-panel-meta {
         display: flex;
-        align-items: center;
-        gap: 6px;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 2px;
         font-size: 12px;
         color: #6a6259;
+        text-align: right;
       }
-      html.dark .chart-controls {
+      html.dark .summary-panel-meta {
         color: #9db9a6;
       }
-      .chart-controls select {
-        border-radius: 10px;
-        border: 1px solid #e5e1da;
-        padding: 4px 8px;
-        font-size: 12px;
-        background: #ffffff;
+      .milk-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
       }
-      html.dark .chart-controls select {
-        background: rgba(26, 44, 32, 0.9);
-        border-color: rgba(255, 255, 255, 0.12);
-        color: #ffffff;
-      }
-      .chart-wrap {
-        position: relative;
-        background: #f6f2ec;
+      .milk-item {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px 10px;
         border-radius: 12px;
-        padding: 8px;
+        background: #f6f2ec;
       }
-      html.dark .chart-wrap {
+      html.dark .milk-item {
         background: rgba(255, 255, 255, 0.06);
       }
-      #summary-chart {
-        width: 100%;
-        height: 180px;
-        display: block;
+      .milk-time {
+        font-size: 13px;
+        font-weight: 600;
       }
-      .chart-empty {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+      .milk-notes {
+        font-size: 12px;
+        color: #6a6259;
+        text-align: right;
+      }
+      html.dark .milk-notes {
+        color: #9db9a6;
+      }
+      .summary-empty {
+        display: none;
+        padding: 14px;
+        text-align: center;
         font-size: 13px;
         color: #8b857e;
       }
-      html.dark .chart-empty {
+      html.dark .summary-empty {
         color: #9db9a6;
       }
       .status {
@@ -360,46 +372,35 @@
           </button>
         </div>
 
+        <div class="summary-section-title">Feed totals</div>
         <section class="summary-grid">
           <div class="summary-card">
-            <div class="summary-label">All events</div>
-            <div class="summary-value" id="summary-total">0</div>
-            <div class="summary-sub" id="summary-total-avg">Avg / 24h: --</div>
+            <div class="summary-label">Total feed duration</div>
+            <div class="summary-value" id="summary-feed-duration">0 min</div>
+            <div class="summary-sub" id="summary-feed-duration-avg">Avg / feed: --</div>
           </div>
           <div class="summary-card">
-            <div class="summary-label">Feeds</div>
-            <div class="summary-value" id="summary-feed">0</div>
-            <div class="summary-sub" id="summary-feed-avg">Avg / 24h: --</div>
+            <div class="summary-label">Expressed total</div>
+            <div class="summary-value" id="summary-expressed-amount">0 ml</div>
+            <div class="summary-sub" id="summary-expressed-avg">Avg / feed: --</div>
           </div>
           <div class="summary-card">
-            <div class="summary-label">Wet</div>
-            <div class="summary-value" id="summary-wee">0</div>
-            <div class="summary-sub" id="summary-wee-avg">Avg / 24h: --</div>
-          </div>
-          <div class="summary-card">
-            <div class="summary-label">Soiled</div>
-            <div class="summary-value" id="summary-poo">0</div>
-            <div class="summary-sub" id="summary-poo-avg">Avg / 24h: --</div>
+            <div class="summary-label">Formula total</div>
+            <div class="summary-value" id="summary-formula-amount">0 ml</div>
+            <div class="summary-sub" id="summary-formula-avg">Avg / feed: --</div>
           </div>
         </section>
 
-        <section class="chart-card">
-          <div class="chart-header">
-            <h2>Time of day</h2>
-            <div class="chart-controls">
-              <label for="summary-type">Event type</label>
-              <select id="summary-type">
-                <option value="all">All events</option>
-                <option value="feed">feed</option>
-                <option value="wee">wee</option>
-                <option value="poo">poo</option>
-              </select>
+        <section class="summary-panel">
+          <div class="summary-panel-header">
+            <h2>Milk express</h2>
+            <div class="summary-panel-meta">
+              <div id="milk-express-count">0 events</div>
+              <div id="milk-express-totals">0 ml • 0 min</div>
             </div>
           </div>
-          <div class="chart-wrap">
-            <svg id="summary-chart" viewBox="0 0 360 180" preserveAspectRatio="none"></svg>
-            <div class="chart-empty" id="summary-chart-empty">No events for this day.</div>
-          </div>
+          <div class="milk-list" id="milk-express-list"></div>
+          <div class="summary-empty" id="milk-express-empty">No milk express events for this day.</div>
         </section>
 
         <div class="status" id="status"></div>


### PR DESCRIPTION
## Summary
- focus summary top cards on feed totals (duration/expressed/formula)
- replace time-of-day chart with milk express list + totals from comments
- add parsing for ml/min in milk express notes

## Testing
- uv run pytest